### PR TITLE
Proposed-MinGWEpsilonFix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then sudo apt-get install valgrind ninja-build ggcov -q -y; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then sudo ln -sf /usr/bin/gcov-4.8 /usr/bin/gcov; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]   ; then brew install valgrind ninja; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]   ; then brew install ninja; fi
 
 script:
   - ninja

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,16 @@
 version: 0.0.{build}
 clone_folder: C:\projects\Mezz_Test
 
+image:
+  - Visual Studio 2017
+
 environment:
   matrix:
   - GENERATOR: MinGW Makefiles
     CompilerPath: C:\msys64\mingw32\bin
   - GENERATOR: MinGW Makefiles
     CompilerPath: C:\msys64\mingw64\bin
-  - GENERATOR: Visual Studio 14 2015 Win64
+  - GENERATOR: Visual Studio 15 2017 Win64
 
 configuration:
   - Debug

--- a/include/UnitTestGroup.h
+++ b/include/UnitTestGroup.h
@@ -50,6 +50,7 @@
 #include <vector>
 #include <chrono>
 #include <functional>
+#include <type_traits>
 
 namespace Mezzanine
 {
@@ -274,9 +275,10 @@ namespace Mezzanine
                                   const String& File = "",
                                   Mezzanine::Whole Line = 0)
             {
+                static_assert(std::is_floating_point<ExpectedResultsType>::value, "Non-float type used to test epsilon.");
                 auto Epsilon(std::numeric_limits<ExpectedResultsType>::epsilon());
-                Boole Within{ (ExpectedResults-Epsilon*PreciseReal(EpsilonCount)) <= ActualResults &&
-                                        (ActualResults <= ExpectedResults+Epsilon*PreciseReal(EpsilonCount)) };
+                Boole Within{ (ExpectedResults-Epsilon*ExpectedResultsType(EpsilonCount)) <= ActualResults &&
+                                        (ActualResults <= ExpectedResults+Epsilon*ExpectedResultsType(EpsilonCount)) };
                 TestResult Result = Test( TestName, Within, IfFalse, IfTrue, FuncName, File, Line);
                 if(EmitIntermediaryTestResults() && Mezzanine::Testing::TestResult::Success != Result)
                 {

--- a/include/UnitTestGroup.h
+++ b/include/UnitTestGroup.h
@@ -275,10 +275,9 @@ namespace Mezzanine
                                   const String& File = "",
                                   Mezzanine::Whole Line = 0)
             {
-                static_assert(std::is_floating_point<ExpectedResultsType>::value, "Non-float type used to test epsilon.");
-                auto Epsilon(std::numeric_limits<ExpectedResultsType>::epsilon());
-                Boole Within{ (ExpectedResults-Epsilon*ExpectedResultsType(EpsilonCount)) <= ActualResults &&
-                                        (ActualResults <= ExpectedResults+Epsilon*ExpectedResultsType(EpsilonCount)) };
+                auto Epsilon( std::numeric_limits<ExpectedResultsType>::epsilon() );
+                Boole Within{ (ExpectedResults - Epsilon * ExpectedResultsType(EpsilonCount)) <= ActualResults &&
+                              (ActualResults <= ExpectedResults + Epsilon * ExpectedResultsType(EpsilonCount)) };
                 TestResult Result = Test( TestName, Within, IfFalse, IfTrue, FuncName, File, Line);
                 if(EmitIntermediaryTestResults() && Mezzanine::Testing::TestResult::Success != Result)
                 {

--- a/test/TestTests.h
+++ b/test/TestTests.h
@@ -74,8 +74,10 @@ void NegativeTestTests::operator ()()
     // This group should serve as examples of failing tests.
     TEST("DefaultTestFailing", false);
     TEST_EQUAL("EqualityTestFailing", 1, 2);
-    TEST_EQUAL_EPSILON("EqualEpsilonFailing", 0.1, 0.2);
-    TEST_EQUAL_MULTI_EPSILON("EqualMultiEpsilonFailing", 0.1, 1.2, 2);
+    TEST_EQUAL_EPSILON("EqualEpsilonFailing-Float", 0.1f, 0.2f);
+    TEST_EQUAL_EPSILON("EqualEpsilonFailing-Double", 0.1, 0.2);
+    TEST_EQUAL_MULTI_EPSILON("EqualMultiEpsilonFailing-Float", 0.1f, 1.2f, 2);
+    TEST_EQUAL_MULTI_EPSILON("EqualMultiEpsilonFailing-Double", 0.1, 1.2, 2);
     TEST_RESULT("TestResultFailing", Mezzanine::Testing::TestResult::Failed);
     TEST_THROW("TestThrowFailing", std::invalid_argument, []{ throw std::out_of_range("pass"); });
     TEST_THROW("TestThrowFailingNonException", std::invalid_argument, []{ throw std::string("pass"); });
@@ -120,8 +122,10 @@ void TestTests::operator ()()
     TEST("DefaultTestPassing", true);
     TEST_EQUAL("EqualityTestPassing", 1, 1);
     TEST_WARN("WarningTestPassing", true);
-    TEST_EQUAL_EPSILON("EqualEpsilonPassing", 0.1, 0.1);
-    TEST_EQUAL_MULTI_EPSILON("EqualMultiEpsilonPassing", 0.1, 0.1*1.00, 2);
+    TEST_EQUAL_EPSILON("EqualEpsilonPassing-Float", 0.1f, 0.1f);
+    TEST_EQUAL_EPSILON("EqualEpsilonPassing-Double", 0.1, 0.1);
+    TEST_EQUAL_MULTI_EPSILON("EqualMultiEpsilonPassing-Float", 0.1f, 0.1f * 1.00f, 2);
+    TEST_EQUAL_MULTI_EPSILON("EqualMultiEpsilonPassing-Double", 0.1, 0.1 * 1.00, 2);
     TEST_RESULT("TestResultPassing", Mezzanine::Testing::TestResult::Success);
     TEST_THROW("TestThrowPassing", std::invalid_argument, []{ throw std::invalid_argument("pass"); });
     TEST_NO_THROW("TestNoThrowPassing", []{});


### PR DESCRIPTION
Updated the epsilon test to be better about testing floats.

On some platforms (MinGW in particular) double promotion is a warning, which is forced because "PreciseReal", aka double, was being used in the arithmetic.  This change will instead use the deduced "ExpectedResultsType" in the arithmetic which will prevent a promotion when floats are used.  As an additional layer of safety I've also added a static_assert to verify it is a float type (float, double, long double).