### PR TITLE
Update to CMake 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@
 #   John Blackwood - makoenergy02@gmail.com
 
 ########################################################################################################################
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 project(Test)
 message(STATUS "${PROJECT_NAME} - Starting Configuration.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@
 #   John Blackwood - makoenergy02@gmail.com
 
 ########################################################################################################################
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.13)
 project(Test)
 message(STATUS "${PROJECT_NAME} - Starting Configuration.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@
 #   John Blackwood - makoenergy02@gmail.com
 
 ########################################################################################################################
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(Test)
 message(STATUS "${PROJECT_NAME} - Starting Configuration.")
 


### PR DESCRIPTION
This should fix some deprecated warnings from CMake 3.19, that run during Jagati tests and will be present as game devs update.

3.10 is the version to ship with Ubuntu 18.04 LTS, and every platform should have easy access to at least this.